### PR TITLE
Changes to References in Demo section

### DIFF
--- a/src/components/DemoSection.css
+++ b/src/components/DemoSection.css
@@ -53,6 +53,19 @@
     text-align: left;
 }
 
+.resource-column p{
+    font-size: 33px;
+    padding-bottom: 3px;
+}
+
+.resource-column a{
+    text-decoration: underline;
+}
+
+.resource-column a:hover{
+    color: #479CCF;
+}
+
 .resource-column ul {
     text-align: center;
     list-style: none;
@@ -62,7 +75,36 @@
 .resource-column li {
     text-align: center;
     margin-bottom: 10px;
+    text-underline-offset:3px;
 }
+
+.logos--unity {
+    display: inline-block;
+    width: 0.98em;
+    height: 0.8em;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 263'%3E%3Cpath fill='white' d='m166.872 131.237l45.91-79.275l22.184 79.275l-22.185 79.256zm-22.376 12.874l45.916 79.262l-79.966-20.486l-57.77-58.776zm45.906-105.033l-45.906 79.275h-91.82l57.77-58.78zm65.539 65.18L227.933.06l-104.54 27.925l-15.475 27.207l-31.401-.225L0 131.244l76.517 76.259h.003l31.388-.232l15.497 27.207l104.528 27.92L255.94 158.22l-15.906-26.982z'/%3E%3C/svg%3E");
+}
+
+.icon-park-outline--api {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='3.6' d='m37 22l-3 3l-11-11l3-3c1.5-1.5 7-4 11 0s1.5 9.5 0 11m5-16l-5 5M11 26l3-3l11 11l-3 3c-1.5 1.5-7 4-11 0s-1.5-9.5 0-11m12 6l4-4M6 42l5-5m5-12l4-4'/%3E%3C/svg%3E");
+}
+
+.mdi--script {
+    display: inline-block;
+    width: 1em;
+    height: 0.8em;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M17.8 20c-.4 1.2-1.5 2-2.8 2H5c-1.7 0-3-1.3-3-3v-1h12.2c.4 1.2 1.5 2 2.8 2zM19 2H8C6.3 2 5 3.3 5 5v11h11v1c0 .6.4 1 1 1h1V5c0-.6.4-1 1-1s1 .4 1 1v1h2V5c0-1.7-1.3-3-3-3'/%3E%3C/svg%3E");
+}
+
 
 @media screen and (max-width: 1198px) {
     .demo-container {

--- a/src/components/DemoSection.jsx
+++ b/src/components/DemoSection.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Fragment} from "react";
 import "./DemoSection.css";
 
 const DemoSection = () => {
@@ -62,18 +62,23 @@ const DemoSection = () => {
                 </p>
             </div>
             <div className="resource-column">
-                <h2>* Resources *</h2>
+                <p><b>Resources</b></p>
                 <ul>
                     <li>
-                        <a href="https://docs.unity3d.com/Manual/index.html">Unity Docs</a>
+                        <span className="logos--unity"></span>
+                        <a href="https://docs.unity3d.com/Manual/index.html">Unity
+                        Docs</a>
                     </li>
                     <li>
+                        <span className="mdi--script"></span>
                         <a href="https://docs.unity3d.com/ScriptReference/">Script Reference</a>
                     </li>
                     <li>
+                    <span className="icon-park-outline--api"></span>
                         <a href="http://www.google.com">API Reference</a>
                     </li>
                     <li>
+                    <span className="logos--unity"></span>
                         <a href="https://unity.com/learn/get-started">Unity Learning</a>
                     </li>
                 </ul>


### PR DESCRIPTION
## What does this PR do?

This PR changes the way the references looked and interacted in the Demo section of the Timewarp site.

Fixes #61 


![Screenshot from 2024-05-15 10-22-08](https://github.com/Akshatchaube01/TimeWarp/assets/107802976/2423b27f-ba87-4b02-b31f-dd576e622a0a)
![Screenshot from 2024-05-15 10-37-21](https://github.com/Akshatchaube01/TimeWarp/assets/107802976/21ac5133-0f69-4cdb-afbe-09f5dd986212)


## Changes made

- Enhanced reference formatting to resemble clickable links for better user recognition.

- Implemented a hover effect that changes the reference color to blue, providing visual feedback on interaction.

- Introduced icons to visually categorize references based on their field, improving information organization and scannability.


