### PR TITLE
 Toggle Button Doesn't Close Automatically on Navbar Links Click (Mobile View) #103

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -7,6 +7,11 @@ const Navbar = () => {
 
     const isActive = (path) => location.pathname === path ? 'text-[#00bfff] underline' : 'text-white';
 
+    // Function to handle link clicks and close the menu
+    const handleLinkClick = () => {
+        setMenuOpen(false);
+    };
+
     return (
         <nav className="z-50 h-16 flex items-center justify-between sticky top-0 w-screen backdrop-filter backdrop-blur-lg bg-opacity-40 p-4">
             <style>
@@ -21,22 +26,28 @@ const Navbar = () => {
             </button>
             <ul className={`absolute bg-black opacity-80 gap-5 md:relative top-full left-0 md:left-auto md:top-auto w-full md:flex md:items-center md:justify-center  md:bg-transparent transition-all duration-300 ease-in-out ${isMenuOpen ? 'flex' : 'hidden'} flex-col md:flex-row list-none m-0 p-4 gap-x-10 text-sm md:text-base lg:text-lg xl:text-xl 2xl:text-3xl`}>
                 <li className="hover:underline text-white md:text-black text-center md:text-left">
-                    <NavLink to="/" className={isActive('/')}><i className="ri-home-fill"></i> Home</NavLink>
+                    {/* Adding onClick handler to close the menu */}
+                    <NavLink to="/" className={isActive('/')} onClick={handleLinkClick}><i className="ri-home-fill"></i> Home</NavLink>
                 </li>
                 <li className="hover:underline text-white md:text-black text-center md:text-left">
-                    <NavLink to="/AboutUs" className={isActive('/AboutUs')}><i className="ri-building-fill"></i> About Us</NavLink>
+                    {/* Adding onClick handler to close the menu */}
+                    <NavLink to="/AboutUs" className={isActive('/AboutUs')} onClick={handleLinkClick}><i className="ri-building-fill"></i> About Us</NavLink>
                 </li>
                 <li className="hover:underline text-white md:text-black text-center md:text-left">
-                    <NavLink to="/DemoSection" className={isActive('/DemoSection')}><i className="ri-service-fill"></i> Demo Section</NavLink>
+                    {/* Adding onClick handler to close the menu */}
+                    <NavLink to="/DemoSection" className={isActive('/DemoSection')} onClick={handleLinkClick}><i className="ri-service-fill"></i> Demo Section</NavLink>
                 </li>
                 <li className="hover:underline text-white md:text-black text-center md:text-left">
-                    <NavLink to="/Models" className={isActive('/Models')}><i className="ri-layout-2-fill"></i> Models</NavLink>
+                    {/* Adding onClick handler to close the menu */}
+                    <NavLink to="/Models" className={isActive('/Models')} onClick={handleLinkClick}><i className="ri-layout-2-fill"></i> Models</NavLink>
                 </li>
                 <li className="hover:underline text-white md:text-black text-center md:text-left">
-                    <NavLink to="/ContactUs" className={isActive('/ContactUs')}><i className="ri-customer-service-2-fill"></i> Contact Us</NavLink>
+                    {/* Adding onClick handler to close the menu */}
+                    <NavLink to="/ContactUs" className={isActive('/ContactUs')} onClick={handleLinkClick}><i className="ri-customer-service-2-fill"></i> Contact Us</NavLink>
                 </li>
             </ul>
         </nav>
     );
 };
+
 export default Navbar;


### PR DESCRIPTION
### Describe the bug
In the mobile view of the website, the toggle button on the navbar fails to close automatically upon clicking any of the navbar links. This issue results in an inconvenience for users navigating the site on mobile devices as the navbar remains open, obstructing the view of the content.

So I have fixed this issue by making a new function to handle link clicks and close the menu as - 
```
const handleLinkClick = () => {
        setMenuOpen(false);
    };
```

And added` onClick handler` to close the menu on each items of navbar.

### Screenshots

**Screenshot with issues -**
![image](https://github.com/Akshatchaube01/TimeWarp/assets/115466381/b04c5c76-ea5a-4432-84da-f0dda286925a)

**Screenshot of fixed issues -**
![image](https://github.com/Akshatchaube01/TimeWarp/assets/115466381/3cd41eac-6967-464b-a389-98af81108d80)


### Checklist:

-  [ X] I have performed a self-review of my code
-  [ X] I have read and followed the Contribution Guidelines.
-  [ X] I have tested the changes thoroughly before submitting this pull request.
-  [X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
-  [X ] I have commented my code, particularly in hard-to-understand areas.

